### PR TITLE
Add size details to CircuitError::InvalidInputSize

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -181,7 +181,7 @@ impl Circuit {
 
         // Validate input size
         if inputs.len() != input_nodes.len() {
-            return Err(CircuitError::InvalidInputSize(inputs.len() as u32, input_nodes.len() as u32));
+            return Err(CircuitError::InvalidInputSize { received: inputs.len() as u32, need: input_nodes.len() as u32 });
         }
 
         let mut local_node_values = HashMap::new();
@@ -282,8 +282,8 @@ impl Circuit {
 pub enum CircuitError {
     #[error("Cyclic dependency detected")]
     CyclicDependencyDetected,
-    #[error("Invalid input size: received {0}, need {1}")]
-    InvalidInputSize(u32, u32),
+    #[error("Invalid input size")]
+    InvalidInputSize { received: u32, need: u32 },
     #[error("Node {0} already exists")]
     NodeAlreadyExists(u32),
     #[error("Node {0} not found")]
@@ -430,7 +430,7 @@ mod tests {
         circuit.add_node(2, Node::new()).unwrap();
 
         let err = circuit.execute(&[1]);
-        assert_eq!(err, Err(CircuitError::InvalidInputSize(1, 0)));
+        assert_eq!(err, Err(CircuitError::InvalidInputSize { received: 1, need: 0 }));
     }
 
     #[test]

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -181,7 +181,7 @@ impl Circuit {
 
         // Validate input size
         if inputs.len() != input_nodes.len() {
-            return Err(CircuitError::InvalidInputSize);
+            return Err(CircuitError::InvalidInputSize(inputs.len() as u32, input_nodes.len() as u32));
         }
 
         let mut local_node_values = HashMap::new();
@@ -282,8 +282,8 @@ impl Circuit {
 pub enum CircuitError {
     #[error("Cyclic dependency detected")]
     CyclicDependencyDetected,
-    #[error("Invalid input size")]
-    InvalidInputSize,
+    #[error("Invalid input size: received {0}, need {1}")]
+    InvalidInputSize(u32, u32),
     #[error("Node {0} already exists")]
     NodeAlreadyExists(u32),
     #[error("Node {0} not found")]
@@ -430,7 +430,7 @@ mod tests {
         circuit.add_node(2, Node::new()).unwrap();
 
         let err = circuit.execute(&[1]);
-        assert_eq!(err, Err(CircuitError::InvalidInputSize));
+        assert_eq!(err, Err(CircuitError::InvalidInputSize(1, 0)));
     }
 
     #[test]


### PR DESCRIPTION
I ran into `InvalidInputSize` while testing circom-2-arithc and had to resort to trial-and-error to find what input size the lib wanted. I think there's a related bug explaining why the input size wasn't what I expected from the circom code, but I'll address that separately.