### PR TITLE
Fixes related to infix ops PR

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -207,8 +207,8 @@ impl Circuit {
             for &input in &[gate.left_input, gate.right_input] {
                 dependency_graph
                     .entry(input)
-                    .or_insert_with(HashSet::new)
-                    .insert(output);
+                    .or_insert_with(Vec::new)
+                    .push(output);
                 *in_degree.entry(output).or_insert(0) += 1;
             }
         }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -37,6 +37,7 @@ pub enum Operation {
     Subtract,
     Multiply,
     Divide,
+    IntegerDivide,
     Exponentiate,
     Modulus,
 
@@ -91,6 +92,7 @@ impl Gate {
             Operation::Subtract => left_input - right_input,
             Operation::Multiply => left_input * right_input,
             Operation::Divide => left_input / right_input, // Will panic if right_input is zero
+            Operation::IntegerDivide => left_input / right_input, // Will panic if right_input is zero
             Operation::Exponentiate => left_input.pow(right_input),
             Operation::Modulus => left_input % right_input, // Will panic if right_input is zero
             Operation::Equals => (left_input == right_input) as u32,

--- a/tests/x_mul_x.rs
+++ b/tests/x_mul_x.rs
@@ -1,0 +1,20 @@
+use sim_circuit::circuit::{Circuit, Gate, Node, Operation};
+
+#[test]
+fn test_x_mul_x() {
+    let mut circuit = Circuit::new();
+
+    // Initialize nodes
+    circuit.add_node(1, Node::new()).unwrap();
+    circuit.add_node(2, Node::new()).unwrap();
+
+    // out = x * x
+    circuit
+        .add_gate(Gate::new(Operation::Multiply, 1, 1, 2))
+        .unwrap();
+
+    let inputs = vec![5];
+    let outputs = circuit.execute(&inputs).unwrap();
+
+    assert_eq!(outputs, vec![25]);
+}


### PR DESCRIPTION
## Add `Operation::IntegerDivide`

This is a bit awkward because it's currently the same as `Operation::Divide`. However I think it's helpful to set up this distinction so that we can treat them differently in the future. In circom `Divide` means division within the finite field (eg 1/2 is 3 in modulo 5, since 3*2=1 mod 5). Because the available operations depends on the MPC backend, I think we should parameterize sim-circuit over the number system, but I'll make a discussion for this elsewhere.

[Discord discussion thread](https://discord.com/channels/943612659163602974/1240455943393771520/1240456178765398066).

## Fix input counting bug when constructing graph for Kahn's Algorithm

I was getting `CircuitError::CyclicDependencyDetected` for this circuit:

```circom
pragma circom 2.0.0;

template xEqX() {
    signal input x;
    signal output out;
    
    out <== x == x;
}

component main = xEqX();
```

(This issue came up because the test I wrote for all infix ops contained several examples like this.)

I discovered the reason for this was that a `HashSet` is used for the dependencies of each node. This meant that when inserting a duplicate dependency, it was ignored by the hashset but the in-degree was still incremented. Kahn's Algorithm requires that in-degree can be decremented for each edge (including multiple edges from the same input) rather than each distinct dependency.